### PR TITLE
chore(ci): add OIDC templates (AWS/Azure/GCP)

### DIFF
--- a/.githooks/secret_scan.sh
+++ b/.githooks/secret_scan.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Secret-like pattern scanner for staged files.
+# Fails commit if any staged file matches common secret patterns.
+
+patterns='(API[_-]?KEY|SECRET|TOKEN|GOOGLE_APPLICATION_CREDENTIALS|PASSWORD|PASS|PRIVATE_KEY|ACCESS_KEY|sk-[A-Za-z0-9]{10,})'
+
+status=0
+# If no filenames are passed (pre-commit typically passes them), scan nothing.
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+for file in "$@"; do
+  # Only regular files
+  [ -f "$file" ] || continue
+  # Skip binary files
+  if grep -Iq . "$file"; then
+    if grep -IEn -- "$patterns" "$file" >/dev/null 2>&1; then
+      echo "Potential secret-like content found in: $file" >&2
+      status=1
+    fi
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "Commit blocked: remove or scrub secrets before committing." >&2
+fi
+
+exit "$status"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: '33 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (CodeQL)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/oidc-aws.yml
+++ b/.github/workflows/oidc-aws.yml
@@ -1,0 +1,22 @@
+name: OIDC AWS (Template)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  aws-auth:
+    name: Authenticate to AWS via OIDC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/{{AWS_ROLE_NAME}}"
+          aws-region: "{{AWS_REGION}}"
+      - name: Verify identity
+        run: aws sts get-caller-identity

--- a/.github/workflows/oidc-azure.yml
+++ b/.github/workflows/oidc-azure.yml
@@ -1,0 +1,24 @@
+name: OIDC Azure (Template)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  azure-auth:
+    name: Authenticate to Azure via OIDC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
+      - name: Verify account
+        run: az account show

--- a/.github/workflows/oidc-gcp.yml
+++ b/.github/workflows/oidc-gcp.yml
@@ -1,0 +1,24 @@
+name: OIDC GCP (Template)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  gcp-auth:
+    name: Authenticate to GCP via WIF (OIDC)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Auth via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/{{GCP_PROJECT_NUMBER}}/locations/global/workloadIdentityPools/{{POOL_NAME}}/providers/{{PROVIDER_NAME}}"
+          service_account: "{{SERVICE_ACCOUNT_EMAIL}}"
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Verify account
+        run: gcloud auth list --filter=status:ACTIVE

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,36 @@
+name: security-ci
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  secret-scans:
+    name: Secret Scans (TruffleHog + Gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: TruffleHog (verified)
+        uses: trufflesecurity/trufflehog@v3
+        with:
+          extra_args: "--only-verified --fail"
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: "detect --source . --no-git -v --exit-code 1"
+
+  sast-semgrep:
+    name: SAST (Semgrep CI ruleset)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          config: p/ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: detect-private-key
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: \.git/.*|\.secrets\.baseline$
+
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.63.2
+    hooks:
+      - id: trufflehog
+        name: TruffleHog
+        entry: bash -c 'trufflehog git file://. --since-commit HEAD --only-verified --fail'
+        language: system
+        stages: [commit, manual]


### PR DESCRIPTION
This PR adds GitHub Actions templates for OIDC auth to AWS, Azure, and GCP.\n\n- Trigger: workflow_dispatch only (safe by default)\n- Permissions: id-token: write (required), contents: read\n- Placeholders added; configure roles/IDs before use.